### PR TITLE
Fix writing pprNo.csv on fresh clone.

### DIFF
--- a/src/pokemon_index_array_gen.py
+++ b/src/pokemon_index_array_gen.py
@@ -1,5 +1,6 @@
 # this file generates an array mapping pokedex numbers to indices into the array of all PiiProp (pokemon properties).
 # this is necessary to account for the extra PiiProp entries for alternate pokemon forms.
+import os
 
 POKEDEX_LENGTH = 496
 
@@ -31,6 +32,6 @@ for dex_index in range(0, POKEDEX_LENGTH - 1):
 
 header_csv = ','.join([f"{x}" for x in pokemon_index_array])
 
+os.makedirs("build/WPSE01_01/include", exist_ok=True)
 with open("build/WPSE01_01/include/pprNo.csv", "w+") as f:
     f.write(header_csv)
-    


### PR DESCRIPTION
Hey there, looks like the changes made in [my previous pr](https://github.com/KooShnoo/pokemon-rumble/pull/2) were accidentally removed when you rewrote the code in https://github.com/KooShnoo/pokemon-rumble/commit/11c112f7548b26ab2cecfcf52e201b8d3b76120f so users will run into the following issue on a fresh clone of the repo.

```
❯ python src/pokemon_index_array_gen.py
Traceback (most recent call last):
  File "/home/-----/Desktop/Ruble/pokemon-rumble/src/pokemon_index_array_gen.py", line 34, in <module>
    with open("build/WPSE01_01/include/pprNo.csv", "w+") as f:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'build/WPSE01_01/include/pprNo.csv'

```